### PR TITLE
Firefox scrollbar support

### DIFF
--- a/fri-dark.user.css
+++ b/fri-dark.user.css
@@ -553,6 +553,12 @@ span.unread
 	background: #9f9f9f;
 }
 
+/* Firefox Scrollbar support */
+#nav-drawer, html {
+	scrollbar-width: thin;
+	scrollbar-color: #403e3e #464646;
+}
+
 .popover
 {
 	background-color: #161616;


### PR DESCRIPTION
Custom scrollbars work in WebKit browsers, but Firefox uses `scrollbar-width` and `scrollbar-color`, ignoring the current styles. Here is the same scrollbar, but with added support for Firefox.


| Current (Chrome) | Current (Firefox) | Fixed (Firefox) |
| ------------- | ------------- | ------------- |
| ![dark-css-current-chrome](https://user-images.githubusercontent.com/11632445/75461638-5d5a2c80-5983-11ea-8322-64df621ffe33.png) | ![dark-css-before](https://user-images.githubusercontent.com/11632445/75461077-86c68880-5982-11ea-866b-edf7b8ef6c3d.png)  | ![dark-css-after](https://user-images.githubusercontent.com/11632445/75461092-8c23d300-5982-11ea-95a8-22d7f02b96ae.png)  |
